### PR TITLE
Add support for repeatable files, kinda hacky

### DIFF
--- a/src/Horton/SqlServer/SchemaInfo.cs
+++ b/src/Horton/SqlServer/SchemaInfo.cs
@@ -66,7 +66,15 @@ namespace Horton.SqlServer
 
         public IReadOnlyList<AppliedMigrationRecord> AppliedMigrations { get { return appliedMigrations; } }
 
+
         public void ApplyMigration(ScriptFile migration)
+        {
+            ApplyMigration(migration, true);
+        }
+        // new parameter doRecord:  Should we run RecordMigration()?
+        // XXX hack to run repeatable files without trying to overwrite schema info in DB
+        // There has to be a better way to do this.
+        public void ApplyMigration(ScriptFile migration, bool doRecord)
         {
             AssertNotDisposed();
             var commands = ParseSqlScript(migration.Content);
@@ -87,7 +95,10 @@ namespace Horton.SqlServer
                     }
                 }
                 sw.Stop();
-                RecordMigration(transaction, migration, sw.Elapsed.TotalMilliseconds);
+                if (doRecord)
+                {
+                    RecordMigration(transaction, migration, sw.Elapsed.TotalMilliseconds);
+                }
                 transaction.Commit();
             }
         }

--- a/src/Horton/UpdateCommand.cs
+++ b/src/Horton/UpdateCommand.cs
@@ -21,29 +21,39 @@ namespace Horton
                 Console.WriteLine("The following scripts will execute...");
 
                 var toExecute = new List<ScriptFile>();
+                // XXX hack to run repeatable files without trying to overwrite schema info in DB
+                var dontRecordThese = new List<ScriptFile>();
                 bool willExecuteMigrations = true;
 
                 foreach (var file in loader.Files)
                 {
                     var existingRecord = schemaInfo.AppliedMigrations.SingleOrDefault(x => x.FileNameMD5Hash == file.FileNameHash);
-                    if (existingRecord != null)
-                    {
-                        if (file.ContentConflict(existingRecord.ContentSHA1Hash))
-                        {
-                            var prevColor = Console.ForegroundColor;
-                            Console.ForegroundColor = ConsoleColor.Red;
-                            Console.WriteLine($"\nCONFLICT: The script \"{file.FileName}\" has changed since it was applied on \"{existingRecord.AppliedUTC.ToString("yyyy-MM-dd HH:mm:ss.ff")}\".");
-                            Console.ForegroundColor = prevColor;
-                            willExecuteMigrations = false;
-                        }
-                    }
-                    else
+                    if (existingRecord == null)
                     {
                         var prevColor = Console.ForegroundColor;
                         Console.ForegroundColor = ConsoleColor.DarkGreen;
                         Console.WriteLine($"\n\"{file.FileName}\" will execute on UPDATE.");
                         Console.ForegroundColor = prevColor;
                         toExecute.Add(file);
+                    }
+                    else if (file.TypeCode == 2)
+                    {
+                        // typeCode 2 is a repeatable file, it will always run (procs/views have desired state)
+                        var prevColor = Console.ForegroundColor;
+                        Console.ForegroundColor = ConsoleColor.DarkGreen;
+                        Console.WriteLine($"\n\"{file.FileName}\" will always execute on UPDATE, since it's a repeatable file.");
+                        Console.ForegroundColor = prevColor;
+                        toExecute.Add(file);
+                        // XXX hack to run repeatable files without trying to overwrite schema info in DB
+                        dontRecordThese.Add(file);
+                    }
+                    else if (file.ContentConflict(existingRecord.ContentSHA1Hash))
+                    {
+                        var prevColor = Console.ForegroundColor;
+                        Console.ForegroundColor = ConsoleColor.Red;
+                        Console.WriteLine($"\nCONFLICT: The script \"{file.FileName}\" has changed since it was applied on \"{existingRecord.AppliedUTC.ToString("yyyy-MM-dd HH:mm:ss.ff")}\".");
+                        Console.ForegroundColor = prevColor;
+                        willExecuteMigrations = false;
                     }
                 }
 
@@ -73,7 +83,11 @@ namespace Horton
                     var prevColor = Console.ForegroundColor;
                     Console.ForegroundColor = ConsoleColor.DarkGreen;
                     Console.Write($"\nApplying \"{file.FileName}\"... ");
-                    schemaInfo.ApplyMigration(file);
+
+                    // XXX hack to run repeatable files without trying to overwrite schema info in DB
+                    bool shouldRecord = !dontRecordThese.Contains(file);
+                    schemaInfo.ApplyMigration(file, shouldRecord);
+
                     Console.WriteLine("done.");
                     Console.ForegroundColor = prevColor;
                 }


### PR DESCRIPTION
- Repeatable files will always be run when using the UPDATE command (To
  be used for desired state configuration for sprocs and views)
- After the first run, they don't run RecordMigration (Not sure how bad
  this is)
- Any file beginning with digits and an underscore (example:
  "0001_blah_blah_blah_blah") is a migration file, any other file is a
  repeatable file
- I don't think this is documented in this version

There is probably a better way to do this... but I got something that worked and wanted to share it.
